### PR TITLE
DEV: Добавление возможности сопоставить email отправки и реальный email отправки.

### DIFF
--- a/app/Libraries/SendEmail.php
+++ b/app/Libraries/SendEmail.php
@@ -75,6 +75,10 @@ class SendEmail
             $mail->setNameFrom(config('meta.name')); // вот тут было длинное
             $mail->setAddressFrom(config('general.email'));
 
+            if (config('general.confirm_sender')) {
+                $mail->setParameters('-f' . config('general.email'));
+            }
+
             $mail->setTo($email);
 
             $mail->setTitle($subject);

--- a/config/general.php
+++ b/config/general.php
@@ -35,5 +35,9 @@ return [
     // Email of the site administration
     // Email администрации сайта
     'email'             => '***@site.ru',
+    // Confirm sender (email must be configured on the server).
+    // Подтвердить отправителя (email должен быть настроен на сервере).
+    'confirm_sender'    =>  true,
+
 
 ];

--- a/config/general.php
+++ b/config/general.php
@@ -37,7 +37,7 @@ return [
     'email'             => '***@site.ru',
     // Confirm sender (email must be configured on the server).
     // Подтвердить отправителя (email должен быть настроен на сервере).
-    'confirm_sender'    =>  true,
+    'confirm_sender'    =>  false,
 
 
 ];


### PR DESCRIPTION
Чтобы письмам уделялось больше доверия в почтовых сервисах теперь можно установить тот-же email для сервера отправки, что и указанный для администратора.  Проще говоря, возможное предупреждение, что отправлено с адреса сервера на самом деле, пропадет.
По умолчанию выключено, так как чтобы работало, нужно установить email администратора в конфиге веб-сервера.
В php.ini (sendmail_path = ... -f'email@example.com
Для некоторых хостингов достаточно просто добавить такой email в панели управления.

