### PR TITLE
FIX: Исправлено неправильное отображение символов в посте

### DIFF
--- a/app/Models/PostModel.php
+++ b/app/Models/PostModel.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use DB;
+use App\Traits\Post;
 
 class PostModel extends \Hleb\Scheme\App\Models\MainModel
-{
+{   
+    use Post;
+    
     public static function create($params)
     {
         $sql = "INSERT INTO posts(post_title, 
@@ -45,6 +48,8 @@ class PostModel extends \Hleb\Scheme\App\Models\MainModel
                                     :post_top,
                                     :post_url,
                                     :post_url_domain)";
+
+        self::convertingToSpecialChar($params, ['post_content', 'post_title']);
 
         DB::run($sql, $params);
 
@@ -219,6 +224,8 @@ class PostModel extends \Hleb\Scheme\App\Models\MainModel
                     post_closed           = :post_closed,
                     post_top              = :post_top
                          WHERE post_id = :post_id";
+
+        self::convertingToSpecialChar($params, ['post_content', 'post_title']);
 
         return DB::run($sql, $params);
     }

--- a/app/Traits/Post.php
+++ b/app/Traits/Post.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Traits;
+
+trait Post
+{
+    /**
+     * Преобразует указанные значения в массиве по выбранным именам.
+     * Нужно для того, чтобы в массиве не оказались поля с небезопасными символами.
+     * @param array $list
+     * @param array $names
+     */
+    private static function convertingToSpecialChar(&$list, $names)
+    {
+        foreach($names as $name) {
+            if (isset($list[$name])) {
+                $list[$name] = str_replace(['<', '>'], ['&lt;', '&gt;'], $list[$name]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Решена проблема, при которой в коде неправильно обрабатывались спецсимволы `<` и `>`, также такая проверка усиливает безопасность поста. Под кодом имеется ввиду вставляемый код в пост, там при редактировании и наличии символов этих слетала верстка.