### PR TITLE
FIX: Исправление названия поля

### DIFF
--- a/app/Controllers/Auth/LoginController.php
+++ b/app/Controllers/Auth/LoginController.php
@@ -19,7 +19,7 @@ class LoginController extends Controller
 
         // If you clicked "Remember", it establishes a user session and registers it
         // Если нажал "Запомнить", то устанавливает сеанс пользователя и регистрирует его
-        $rememberMe = $data['rememberMe'] ?? false;
+        $rememberMe = $data['rememberme'] ?? false;
         if ($rememberMe == 1) {
             (new \App\Controllers\Auth\RememberController())->rememberMe($user['id']);
         }


### PR DESCRIPTION
Опечатка. При отправке поля 'rememberme' всё название в нижнем регистре. Поле в форме здесь https://github.com/LibArea/libarea/blob/b0d78c88a73295265d6b427bbca21cfee21323fb/resources/views/default/_block/form/login.php#L11