### PR TITLE
Add CSS for Tagify with noTags but it's required

### DIFF
--- a/resources/views/default/css/components/tags.css
+++ b/resources/views/default/css/components/tags.css
@@ -101,3 +101,7 @@
   width: 100%;
   max-width: 780px;
 }
+
+.tagify--noTags[required]{ 
+  --tags-border-color: red;
+}

--- a/resources/views/default/css/components/tags.css
+++ b/resources/views/default/css/components/tags.css
@@ -102,6 +102,6 @@
   max-width: 780px;
 }
 
-.tagify--noTags[required]{ 
-  --tags-border-color: red;
+.tagify--noTags[required] {
+  --tags-border-color: #ff0000;
 }


### PR DESCRIPTION
Если поле для выбора тегов обязательое (например - поле Тема в форме редактирования Поста) и поле не заполнено, то  форма не отправляется, но пользователю не понятно почему не отправляется (нет никаких уведомлений). 

Причина -  Tagify "прячет" базовый "<input>" и в связи с этим стандартное сообщение браузера на атрибут "required" не отрабатывает.

Решение - необходимо дополнительно проверять поле и выводить сообщение.

Текущее решение  - показываем красную рамку вокруг поля выбора тегов, если поле пустое и установлен атрибут "requiered". 

