### PR TITLE
FIX: command execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
         "optimize-autoloader": true
     },
     "scripts": {
-        "post-root-package-install": [
+        "post-create-project-cmd": [
             "@php console project-setup-task --clear"
         ]
     },


### PR DESCRIPTION
Выполнение скрипта `console project-setup-task` только после `composer create-project`.